### PR TITLE
adding wrapper for proxy header passing.

### DIFF
--- a/backend/internal/nginx.js
+++ b/backend/internal/nginx.js
@@ -157,7 +157,7 @@ const internalNginx = {
 				for (let i = 0; i < host.locations.length; i++) {
 					let locationCopy = Object.assign({}, {access_list_id: host.access_list_id}, {certificate_id: host.certificate_id}, 
 						{ssl_forced: host.ssl_forced}, {caching_enabled: host.caching_enabled}, {block_exploits: host.block_exploits},
-						{allow_websocket_upgrade: host.allow_websocket_upgrade}, {http2_support: host.http2_support},
+						{allow_websocket_upgrade: host.allow_websocket_upgrade}, {forward_proxy_header: host.forward_proxy_header}, {http2_support: host.http2_support},
 						{hsts_enabled: host.hsts_enabled}, {hsts_subdomains: host.hsts_subdomains}, {access_list: host.access_list},
 						{certificate: host.certificate}, host.locations[i]);
 			

--- a/backend/migrations/20220309105452_proxy_header.js
+++ b/backend/migrations/20220309105452_proxy_header.js
@@ -1,0 +1,41 @@
+const migrate_name = 'proxy_header';
+const logger       = require('../logger').migrate;
+
+/**
+ * Migrate
+ *
+ * @see http://knexjs.org/#Schema
+ *
+ * @param   {Object} knex
+ * @param   {Promise} Promise
+ * @returns {Promise}
+ */
+exports.up = function (knex/*, Promise*/) {
+	logger.info('[' + migrate_name + '] Migrating Up...');
+
+	return knex.schema.table('proxy_host', function (proxy_host) {
+		proxy_host.integer('forward_proxy_header').notNull().unsigned().defaultTo(1);
+	})
+		.then(() => {
+			logger.info('[' + migrate_name + '] proxy_host Table altered');
+		});
+
+};
+
+/**
+ * Undo Migrate
+ *
+ * @param   {Object} knex
+ * @param   {Promise} Promise
+ * @returns {Promise}
+ */
+exports.down = function (knex/*, Promise*/) {
+	logger.info('[' + migrate_name + '] Migrating Down...');
+
+	return knex.schema.table('redirection_host', (table) => {
+		table.dropColumn('forward_proxy_header');
+	})
+		.then(function () {
+			logger.info('[' + migrate_name + '] proxy_host Table altered');
+		});
+};

--- a/backend/schema/endpoints/proxy-hosts.json
+++ b/backend/schema/endpoints/proxy-hosts.json
@@ -58,6 +58,11 @@
       "example": true,
       "type": "boolean"
     },
+    "forward_proxy_header": {
+      "description": "forward the proxy hostname to the backend proxy server",
+      "example": true,
+      "type": "boolean"
+    },
     "access_list_id": {
       "$ref": "../definitions.json#/definitions/access_list_id"
     },
@@ -155,6 +160,9 @@
     "allow_websocket_upgrade": {
       "$ref": "#/definitions/allow_websocket_upgrade"
     },
+    "forward_proxy_header": {
+      "$ref": "#/definitions/forward_proxy_header"
+    },
     "access_list_id": {
       "$ref": "#/definitions/access_list_id"
     },
@@ -245,6 +253,9 @@
           "allow_websocket_upgrade": {
             "$ref": "#/definitions/allow_websocket_upgrade"
           },
+          "forward_proxy_header": {
+            "$ref": "#/definitions/forward_proxy_header"
+          },
           "access_list_id": {
             "$ref": "#/definitions/access_list_id"
           },
@@ -317,6 +328,9 @@
           },
           "allow_websocket_upgrade": {
             "$ref": "#/definitions/allow_websocket_upgrade"
+          },
+          "forward_proxy_header": {
+            "$ref": "#/definitions/forward_proxy_header"
           },
           "access_list_id": {
             "$ref": "#/definitions/access_list_id"

--- a/backend/templates/_location.conf
+++ b/backend/templates/_location.conf
@@ -1,9 +1,4 @@
   location {{ path }} {
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-Scheme $scheme;
-    proxy_set_header X-Forwarded-Proto  $scheme;
-    proxy_set_header X-Forwarded-For    $remote_addr;
-    proxy_set_header X-Real-IP		$remote_addr;
     proxy_pass       {{ forward_scheme }}://{{ forward_host }}:{{ forward_port }}{{ forward_path }};
 
     {% if access_list_id > 0 %}
@@ -32,13 +27,6 @@
 
     {% include "_forced_ssl.conf" %}
     {% include "_hsts.conf" %}
-
-    {% if allow_websocket_upgrade == 1 or allow_websocket_upgrade == true %}
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $http_connection;
-    proxy_http_version 1.1;
-    {% endif %}
-
 
     {{ advanced_config }}
   }

--- a/backend/templates/proxy_host.conf
+++ b/backend/templates/proxy_host.conf
@@ -24,6 +24,20 @@ proxy_http_version 1.1;
 
 {{ advanced_config }}
 
+  # Proxy!
+  {% if forward_proxy_header == 1 or forward_proxy_header == true %}
+  proxy_set_header Host $host;
+  {% else %}
+  proxy_set_header Host $proxy_host;
+  {% endif %}
+  include conf.d/include/proxy.conf;
+
+  {% if allow_websocket_upgrade == 1 or allow_websocket_upgrade == true %}
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $http_connection;
+  proxy_http_version 1.1;
+  {% endif %}
+
 {{ locations }}
 
 {% if use_default_location %}
@@ -51,15 +65,6 @@ proxy_http_version 1.1;
 
     {% endif %}
 
-
-    {% if allow_websocket_upgrade == 1 or allow_websocket_upgrade == true %}
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $http_connection;
-    proxy_http_version 1.1;
-    {% endif %}
-
-    # Proxy!
-    include conf.d/include/proxy.conf;
   }
 {% endif %}
 

--- a/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
+++ b/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
@@ -1,5 +1,4 @@
 add_header       X-Served-By $host;
-proxy_set_header Host $host;
 proxy_set_header X-Forwarded-Scheme $scheme;
 proxy_set_header X-Forwarded-Proto  $scheme;
 proxy_set_header X-Forwarded-For    $remote_addr;

--- a/frontend/js/app/nginx/proxy/form.ejs
+++ b/frontend/js/app/nginx/proxy/form.ejs
@@ -72,12 +72,21 @@
                                 </label>
                             </div>
                         </div>
-                        <div class="col-sm-12 col-md-12">
+                        <div class="col-sm-6 col-md-6">
                             <div class="form-group">
                                 <label class="custom-switch">
                                     <input type="checkbox" class="custom-switch-input" name="allow_websocket_upgrade" value="1"<%- allow_websocket_upgrade ? ' checked' : '' %>>
                                     <span class="custom-switch-indicator"></span>
                                     <span class="custom-switch-description"><%- i18n('proxy-hosts', 'allow-websocket-upgrade') %></span>
+                                </label>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-md-6">
+                            <div class="form-group">
+                                <label class="custom-switch">
+                                    <input type="checkbox" class="custom-switch-input" name="forward_proxy_header" value="1"<%- forward_proxy_header ? ' checked' : '' %>>
+                                    <span class="custom-switch-indicator"></span>
+                                    <span class="custom-switch-description"><%- i18n('proxy-hosts', 'forward-proxy-header') %></span>
                                 </label>
                             </div>
                         </div>

--- a/frontend/js/app/nginx/proxy/form.js
+++ b/frontend/js/app/nginx/proxy/form.js
@@ -163,6 +163,7 @@ module.exports = Mn.View.extend({
             data.block_exploits          = !!data.block_exploits;
             data.caching_enabled         = !!data.caching_enabled;
             data.allow_websocket_upgrade = !!data.allow_websocket_upgrade;
+            data.forward_proxy_header    = !!data.forward_proxy_header;
             data.http2_support           = !!data.http2_support;
             data.hsts_enabled            = !!data.hsts_enabled;
             data.hsts_subdomains         = !!data.hsts_subdomains;

--- a/frontend/js/models/proxy-host.js
+++ b/frontend/js/models/proxy-host.js
@@ -19,6 +19,7 @@ const model = Backbone.Model.extend({
             hsts_subdomains:         false,
             caching_enabled:         false,
             allow_websocket_upgrade: false,
+            forward_proxy_header:    true,
             block_exploits:          false,
             http2_support:           false,
             advanced_config:         '',


### PR DESCRIPTION
add a selection to the proxy editing page and passes that down into the templates.
Removed set_proxy_header from locations and moved to server directive. these will inherit down into locations if they are not defined there.